### PR TITLE
add cmake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(debugmalloc)
+
+add_compile_options(-Wall -Wextra -Werror -Wno-format)
+
+aux_source_directory(. SRC)
+
+add_executable(debugmalloc ${SRC})
+
+target_include_directories(debugmalloc PRIVATE "${CMAKE_SOURCE_DIR}")


### PR DESCRIPTION
We can build the project with cmake and it seems to work fine.
```
➜  /Users/junbozheng/project/debugmalloc git:(master) cmake .
-- The C compiler identification is AppleClang 14.0.0.14000029
-- The CXX compiler identification is AppleClang 14.0.0.14000029
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/junbozheng/project/debugmalloc
➜  /Users/junbozheng/project/debugmalloc git:(master) ✗ cmake --build .
[ 33%] Building C object CMakeFiles/debugmalloc.dir/debugmalloc.c.o
[ 66%] Building C object CMakeFiles/debugmalloc.dir/example.c.o
[100%] Linking C executable debugmalloc
[100%] Built target debugmalloc
```

Signed-off-by: Junbo Zheng <3273070@qq.com>